### PR TITLE
file dl change

### DIFF
--- a/Convert-Etl2Pcapng.psd1
+++ b/Convert-Etl2Pcapng.psd1
@@ -23,7 +23,7 @@ produces packet capture events) to pcapng format (readable by Wireshark).
 RootModule = 'Convert-Etl2Pcapng.psm1'
 
 # Version number of this module.
-ModuleVersion = '2021.07.15'
+ModuleVersion = '2022.11.22'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
- etl2pcapng is no longer packaged as a zip file with two archs, but a single x64 binary without compression.
- Modified the code base to handle the new change.
- Fixed some missing bits in Unregister.